### PR TITLE
Lp/rails4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     ruby_enum (0.5.0.beta6)
-      activesupport (>= 3.2)
-      railties (>= 3.2)
+      activesupport (~> 4)
+      railties (~> 4)
 
 GEM
   remote: https://rubygems.org/
@@ -34,10 +34,12 @@ GEM
     json (1.8.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mini_portile (0.6.2)
-    minitest (5.8.1)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    mini_portile2 (2.1.0)
+    minitest (5.9.1)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
+    pkg-config (1.1.7)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -47,7 +49,7 @@ GEM
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6.0)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.2)
+    rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
     railties (4.2.4)
       actionpack (= 4.2.4)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A simple enumeration type for ruby.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'ruby_enum'
+gem 'ruby_enum', "~> 0.4" # for Rails 3
+gem 'ruby_enum', "~> 1.0" # for Rails 4
 ```
 
 And then execute:

--- a/lib/ruby_enum.rb
+++ b/lib/ruby_enum.rb
@@ -19,12 +19,16 @@ module RubyEnum
           return name == expected_name
         end
       end
+
+      super
     end
 
     def respond_to?(method)
       if method.to_s =~ /^(.*)\?/
         enum_names = self.class.all.map(&:name)
         return enum_names.include? $1.to_sym
+      else
+        super
       end
     end
 

--- a/lib/ruby_enum/active_model.rb
+++ b/lib/ruby_enum/active_model.rb
@@ -5,7 +5,7 @@ module RubyEnum
     module AttrEnum
       extend ActiveSupport::Concern
 
-      def assign_attributes(new_attributes, optsions = {})
+      def assign_attributes(new_attributes)
         if new_attributes
           enumeration_attrs = self.class.attr_enums
 

--- a/lib/ruby_enum/version.rb
+++ b/lib/ruby_enum/version.rb
@@ -1,3 +1,3 @@
 module RubyEnum
-  VERSION = "0.4.1"
+  VERSION = "1.0.0"
 end

--- a/ruby_enum.gemspec
+++ b/ruby_enum.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 3.2"
-  spec.add_dependency "railties", ">= 3.2"
+  spec.add_dependency "activesupport", "~> 4"
+  spec.add_dependency "railties", "~> 4"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3.0"


### PR DESCRIPTION
Currently Ruby Enum supports only Rails 3. This PL adds support for Rails 4. Also correctly fixes method missing method to call super (not calling super breaks the chain form a subclass C to Object#method_missing)
