### PR TITLE
Removes const_missing in favor of const_set

### DIFF
--- a/lib/ruby_enum.rb
+++ b/lib/ruby_enum.rb
@@ -19,6 +19,8 @@ module RubyEnum
           return name == expected_name
         end
       end
+
+      super
     end
 
     def respond_to?(method)
@@ -26,9 +28,11 @@ module RubyEnum
         enum_names = self.class.all.map(&:name)
         return enum_names.include? $1.to_sym
       end
+      super
     end
 
     # @return [String] the associated value of the enumeration instance
+    #
     def value
       @_value
     end
@@ -55,12 +59,6 @@ module RubyEnum
   end
 
   module ClassMethods
-
-    # enable retrieving enumeration values as constants
-    def const_missing(name)
-      self[name] || super
-    end
-
     def enum(name, value = nil)
       raise ArgumentError, 'name is required for an enumeration' if name.nil?
 
@@ -76,6 +74,8 @@ module RubyEnum
         end
         _define_instance_accessor_for normalized_name
         _enumeration_values[normalized_name] = new(normalized_name, value)
+
+        const_set normalized_name.to_s.upcase, _enumeration_values[normalized_name]
       end
     end
 

--- a/spec/ruby_enum_spec.rb
+++ b/spec/ruby_enum_spec.rb
@@ -225,4 +225,15 @@ describe RubyEnum do
       end
     end
   end
+  
+  # Pull#4.
+  context 'Constant hijacking' do
+    it 'should not hijack RubyEnum constants' do
+      expect(Coordinate::NORTH.value).to eq 'north'
+      NORTH='HIJACKED'
+      expect(Coordinate::NORTH).to_not eq 'HIJACKED'
+      expect(Coordinate::NORTH).to be_a RubyEnum
+      expect(Coordinate::NORTH.value).to eq 'north'
+    end
+  end
 end


### PR DESCRIPTION
Fixes toplevel constant  warning caused by `const_missing`

**Proof of concept**:
```ruby 
 class Colors
    include RubyEnum

    enum :red, 'red'
  end
   
   # Print the enum 
   puts Colors::RED.value
   => 'red'
  
 # Define the RED constant here again. Note that it has overrided RubyEnum::Red constant
  RED = 'HIJACKED'.freeze
  puts Colors::RED
  => 'HIJACKED'
```

The above has to do on how ruby is searching for constants. When you call RubyEnum::RED ruby will look in the current lexical scope by searching the current module or class (RubyEnum in our case) for a defined RED constant which is not in our case since it is implemented with const_missing. If it can’t find it there, it searches the enclosing scope and so on.

Finally when Ruby has finished searching the constants up the nesting and ancestors chain and didn’t find it, it gives the calling code the last chance by calling the const_missing method. Since we redefined RED in an "upper" layer Ruby will find the Constant and have a match. In our case will return the 'HIJACKED' string. 